### PR TITLE
Fix SQL generation

### DIFF
--- a/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/fstorage/MariaDBFStorage.java
+++ b/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/fstorage/MariaDBFStorage.java
@@ -439,7 +439,7 @@ public abstract class MariaDBFStorage<K, V> implements ConstructableValue<K, V>,
                 type = "VARCHAR(255)";
             }
 
-            builder.append(name).append(" ").append(type);
+            builder.append("`" + name + "`").append(" ").append(type);
             if (name.equals(idName)) {
                 builder.append(" PRIMARY KEY");
             }

--- a/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/fstorage/MariaDBFStorage.java
+++ b/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/fstorage/MariaDBFStorage.java
@@ -16,13 +16,11 @@ import wtf.casper.amethyst.core.utils.AmethystLogger;
 import wtf.casper.amethyst.core.utils.ReflectionUtil;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -396,9 +394,6 @@ public abstract class MariaDBFStorage<K, V> implements ConstructableValue<K, V>,
         final Field[] declaredFields = this.valueClass.getDeclaredFields();
 
         for (Field declaredField : declaredFields) {
-            if (declaredField.isAnnotationPresent(Transient.class)) {
-                continue;
-            }
 
             final String name = declaredField.getName();
             final String type = this.getType(declaredField.getType());
@@ -415,14 +410,18 @@ public abstract class MariaDBFStorage<K, V> implements ConstructableValue<K, V>,
         }
     }
 
-    /*
+    /**
      * Generate an SQL Script to create the table based on the class
      * */
     private String createTableFromObject() {
         final StringBuilder builder = new StringBuilder();
-        final Field[] declaredFields = this.valueClass.getDeclaredFields();
 
-        if (declaredFields.length == 0) {
+        List<Field> fields = Arrays.stream(this.valueClass.getDeclaredFields())
+                .filter(field -> !field.isAnnotationPresent(Transient.class))
+                .filter(field -> !Modifier.isTransient(field.getModifiers()))
+                .toList();
+
+        if (fields.size() == 0) {
             return "";
         }
 
@@ -431,11 +430,7 @@ public abstract class MariaDBFStorage<K, V> implements ConstructableValue<K, V>,
         String idName = IdUtils.getIdName(valueClass);
 
         int index = 0;
-        for (Field declaredField : declaredFields) {
-            index++;
-            if (declaredField.isAnnotationPresent(Transient.class)) {
-                continue;
-            }
+        for (Field declaredField : fields) {
 
             final String name = declaredField.getName();
             String type = this.getType(declaredField.getType());
@@ -449,13 +444,14 @@ public abstract class MariaDBFStorage<K, V> implements ConstructableValue<K, V>,
                 builder.append(" PRIMARY KEY");
             }
 
-            if (index != declaredFields.length) {
+            if (index != fields.size()) {
                 builder.append(", ");
             }
+            index++;
         }
-
         builder.append(") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
 
+        AmethystLogger.debug("Generated SQL: " + builder);
         return builder.toString();
     }
 
@@ -468,9 +464,6 @@ public abstract class MariaDBFStorage<K, V> implements ConstructableValue<K, V>,
         final Field[] declaredFields = this.valueClass.getDeclaredFields();
 
         for (Field declaredField : declaredFields) {
-            if (declaredField.isAnnotationPresent(Transient.class)) {
-                continue;
-            }
             if (declaredField.isAnnotationPresent(StorageSerialized.class)) {
                 final String name = declaredField.getName();
                 final String string = resultSet.getString(name);

--- a/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/fstorage/MariaDBFStorage.java
+++ b/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/fstorage/MariaDBFStorage.java
@@ -17,6 +17,7 @@ import wtf.casper.amethyst.core.utils.ReflectionUtil;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -73,170 +74,190 @@ public abstract class MariaDBFStorage<K, V> implements ConstructableValue<K, V>,
                 return values;
             }
 
-            switch (filterType) {
-                case EQUALS -> {
-                    try (final PreparedStatement statement = this.ds.getConnection().prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " = ?")) {
-                        if (value instanceof UUID) {
-                            statement.setString(1, value.toString());
-                        } else {
-                            statement.setObject(1, value);
-                        }
+            try (final Connection connection = this.ds.getConnection()) {
+                switch (filterType) {
+                    case EQUALS -> {
+                        try (final PreparedStatement statement = connection.prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " = ?")) {
+                            if (value instanceof UUID) {
+                                statement.setString(1, value.toString());
+                            } else {
+                                statement.setObject(1, value);
+                            }
 
-                        final ResultSet resultSet = statement.executeQuery();
-                        while (resultSet.next()) {
-                            values.add(this.construct(resultSet));
+                            final ResultSet resultSet = statement.executeQuery();
+                            while (resultSet.next()) {
+                                values.add(this.construct(resultSet));
+                            }
+
+                            resultSet.close();
+                        } catch (final SQLException e) {
+                            e.printStackTrace();
                         }
-                    } catch (final SQLException e) {
-                        e.printStackTrace();
                     }
-                }
-                case CONTAINS -> {
-                    try (final PreparedStatement statement = this.ds.getConnection().prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " LIKE ?")) {
-                        statement.setObject(1, "%" + value + "%");
-                        final ResultSet resultSet = statement.executeQuery();
-                        while (resultSet.next()) {
-                            values.add(this.construct(resultSet));
+                    case CONTAINS -> {
+                        try (final PreparedStatement statement = connection.prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " LIKE ?")) {
+                            statement.setObject(1, "%" + value + "%");
+                            final ResultSet resultSet = statement.executeQuery();
+                            while (resultSet.next()) {
+                                values.add(this.construct(resultSet));
+                            }
+
+                            resultSet.close();
+                        } catch (final SQLException e) {
+                            e.printStackTrace();
                         }
-                    } catch (final SQLException e) {
-                        e.printStackTrace();
                     }
-                }
-                case STARTS_WITH -> {
-                    try (final PreparedStatement statement = this.ds.getConnection().prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " LIKE ?")) {
-                        statement.setObject(1, value + "%");
-                        final ResultSet resultSet = statement.executeQuery();
-                        while (resultSet.next()) {
-                            values.add(this.construct(resultSet));
+                    case STARTS_WITH -> {
+                        try (final PreparedStatement statement = connection.prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " LIKE ?")) {
+                            statement.setObject(1, value + "%");
+                            final ResultSet resultSet = statement.executeQuery();
+                            while (resultSet.next()) {
+                                values.add(this.construct(resultSet));
+                            }
+                            resultSet.close();
+                        } catch (final SQLException e) {
+                            e.printStackTrace();
                         }
-                    } catch (final SQLException e) {
-                        e.printStackTrace();
                     }
-                }
-                case ENDS_WITH -> {
-                    try (final PreparedStatement statement = this.ds.getConnection().prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " LIKE ?")) {
-                        statement.setObject(1, "%" + value);
-                        final ResultSet resultSet = statement.executeQuery();
-                        while (resultSet.next()) {
-                            values.add(this.construct(resultSet));
+                    case ENDS_WITH -> {
+                        try (final PreparedStatement statement = connection.prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " LIKE ?")) {
+                            statement.setObject(1, "%" + value);
+                            final ResultSet resultSet = statement.executeQuery();
+                            while (resultSet.next()) {
+                                values.add(this.construct(resultSet));
+                            }
+                            resultSet.close();
+                        } catch (final SQLException e) {
+                            e.printStackTrace();
                         }
-                    } catch (final SQLException e) {
-                        e.printStackTrace();
                     }
-                }
-                case GREATER_THAN -> {
-                    try (final PreparedStatement statement = this.ds.getConnection().prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " > ?")) {
-                        statement.setObject(1, value);
-                        final ResultSet resultSet = statement.executeQuery();
-                        while (resultSet.next()) {
-                            values.add(this.construct(resultSet));
-                        }
-                    } catch (final SQLException e) {
-                        e.printStackTrace();
-                    }
-                }
-                case LESS_THAN -> {
-                    try (final PreparedStatement statement = this.ds.getConnection().prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " < ?")) {
-                        statement.setObject(1, value);
-                        final ResultSet resultSet = statement.executeQuery();
-                        while (resultSet.next()) {
-                            values.add(this.construct(resultSet));
-                        }
-                    } catch (final SQLException e) {
-                        e.printStackTrace();
-                    }
-                }
-                case GREATER_THAN_OR_EQUAL_TO -> {
-                    try (final PreparedStatement statement = this.ds.getConnection().prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " >= ?")) {
-                        statement.setObject(1, value);
-                        final ResultSet resultSet = statement.executeQuery();
-                        while (resultSet.next()) {
-                            values.add(this.construct(resultSet));
-                        }
-                    } catch (final SQLException e) {
-                        e.printStackTrace();
-                    }
-                }
-                case LESS_THAN_OR_EQUAL_TO -> {
-                    try (final PreparedStatement statement = this.ds.getConnection().prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " <= ?")) {
-                        statement.setObject(1, value);
-                        final ResultSet resultSet = statement.executeQuery();
-                        while (resultSet.next()) {
-                            values.add(this.construct(resultSet));
-                        }
-                    } catch (final SQLException e) {
-                        e.printStackTrace();
-                    }
-                }
-                case IN -> {
-                    try (final PreparedStatement statement = this.ds.getConnection().prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " IN (?)")) {
-                        statement.setObject(1, value);
-                        final ResultSet resultSet = statement.executeQuery();
-                        while (resultSet.next()) {
-                            values.add(this.construct(resultSet));
-                        }
-                    } catch (final SQLException e) {
-                        e.printStackTrace();
-                    }
-                }
-                case NOT_EQUALS -> {
-                    try (final PreparedStatement statement = this.ds.getConnection().prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " != ?")) {
-                        if (value instanceof UUID) {
-                            statement.setString(1, value.toString());
-                        } else {
+                    case GREATER_THAN -> {
+                        try (final PreparedStatement statement = connection.prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " > ?")) {
                             statement.setObject(1, value);
+                            final ResultSet resultSet = statement.executeQuery();
+                            while (resultSet.next()) {
+                                values.add(this.construct(resultSet));
+                            }
+                            resultSet.close();
+                        } catch (final SQLException e) {
+                            e.printStackTrace();
                         }
-                        final ResultSet resultSet = statement.executeQuery();
-                        while (resultSet.next()) {
-                            values.add(this.construct(resultSet));
+                    }
+                    case LESS_THAN -> {
+                        try (final PreparedStatement statement = connection.prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " < ?")) {
+                            statement.setObject(1, value);
+                            final ResultSet resultSet = statement.executeQuery();
+                            while (resultSet.next()) {
+                                values.add(this.construct(resultSet));
+                            }
+                            resultSet.close();
+                        } catch (final SQLException e) {
+                            e.printStackTrace();
                         }
-                    } catch (final SQLException e) {
-                        e.printStackTrace();
+                    }
+                    case GREATER_THAN_OR_EQUAL_TO -> {
+                        try (final PreparedStatement statement = connection.prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " >= ?")) {
+                            statement.setObject(1, value);
+                            final ResultSet resultSet = statement.executeQuery();
+                            while (resultSet.next()) {
+                                values.add(this.construct(resultSet));
+                            }
+                            resultSet.close();
+                        } catch (final SQLException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                    case LESS_THAN_OR_EQUAL_TO -> {
+                        try (final PreparedStatement statement = connection.prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " <= ?")) {
+                            statement.setObject(1, value);
+                            final ResultSet resultSet = statement.executeQuery();
+                            while (resultSet.next()) {
+                                values.add(this.construct(resultSet));
+                            }
+                            resultSet.close();
+                        } catch (final SQLException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                    case IN -> {
+                        try (final PreparedStatement statement = connection.prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " IN (?)")) {
+                            statement.setObject(1, value);
+                            final ResultSet resultSet = statement.executeQuery();
+                            while (resultSet.next()) {
+                                values.add(this.construct(resultSet));
+                            }
+                            resultSet.close();
+                        } catch (final SQLException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                    case NOT_EQUALS -> {
+                        try (final PreparedStatement statement = connection.prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " != ?")) {
+                            if (value instanceof UUID) {
+                                statement.setString(1, value.toString());
+                            } else {
+                                statement.setObject(1, value);
+                            }
+                            final ResultSet resultSet = statement.executeQuery();
+                            while (resultSet.next()) {
+                                values.add(this.construct(resultSet));
+                            }
+                            resultSet.close();
+                        } catch (final SQLException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                    case NOT_CONTAINS -> {
+                        try (final PreparedStatement statement = connection.prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " NOT LIKE ?")) {
+                            statement.setObject(1, "%" + value + "%");
+                            final ResultSet resultSet = statement.executeQuery();
+                            while (resultSet.next()) {
+                                values.add(this.construct(resultSet));
+                            }
+                            resultSet.close();
+                        } catch (final SQLException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                    case NOT_STARTS_WITH -> {
+                        try (final PreparedStatement statement = connection.prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " NOT LIKE ?")) {
+                            statement.setObject(1, value + "%");
+                            final ResultSet resultSet = statement.executeQuery();
+                            while (resultSet.next()) {
+                                values.add(this.construct(resultSet));
+                            }
+                            resultSet.close();
+                        } catch (final SQLException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                    case NOT_ENDS_WITH -> {
+                        try (final PreparedStatement statement = connection.prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " NOT LIKE ?")) {
+                            statement.setObject(1, "%" + value);
+                            final ResultSet resultSet = statement.executeQuery();
+                            while (resultSet.next()) {
+                                values.add(this.construct(resultSet));
+                            }
+                            resultSet.close();
+                        } catch (final SQLException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                    case NOT_IN -> {
+                        try (final PreparedStatement statement = connection.prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " NOT IN (?)")) {
+                            statement.setObject(1, value);
+                            final ResultSet resultSet = statement.executeQuery();
+                            while (resultSet.next()) {
+                                values.add(this.construct(resultSet));
+                            }
+                            resultSet.close();
+                        } catch (final SQLException e) {
+                            e.printStackTrace();
+                        }
                     }
                 }
-                case NOT_CONTAINS -> {
-                    try (final PreparedStatement statement = this.ds.getConnection().prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " NOT LIKE ?")) {
-                        statement.setObject(1, "%" + value + "%");
-                        final ResultSet resultSet = statement.executeQuery();
-                        while (resultSet.next()) {
-                            values.add(this.construct(resultSet));
-                        }
-                    } catch (final SQLException e) {
-                        e.printStackTrace();
-                    }
-                }
-                case NOT_STARTS_WITH -> {
-                    try (final PreparedStatement statement = this.ds.getConnection().prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " NOT LIKE ?")) {
-                        statement.setObject(1, value + "%");
-                        final ResultSet resultSet = statement.executeQuery();
-                        while (resultSet.next()) {
-                            values.add(this.construct(resultSet));
-                        }
-                    } catch (final SQLException e) {
-                        e.printStackTrace();
-                    }
-                }
-                case NOT_ENDS_WITH -> {
-                    try (final PreparedStatement statement = this.ds.getConnection().prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " NOT LIKE ?")) {
-                        statement.setObject(1, "%" + value);
-                        final ResultSet resultSet = statement.executeQuery();
-                        while (resultSet.next()) {
-                            values.add(this.construct(resultSet));
-                        }
-                    } catch (final SQLException e) {
-                        e.printStackTrace();
-                    }
-                }
-                case NOT_IN -> {
-                    try (final PreparedStatement statement = this.ds.getConnection().prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " NOT IN (?)")) {
-                        statement.setObject(1, value);
-                        final ResultSet resultSet = statement.executeQuery();
-                        while (resultSet.next()) {
-                            values.add(this.construct(resultSet));
-                        }
-                    } catch (final SQLException e) {
-                        e.printStackTrace();
-                    }
-                }
+            } catch (final SQLException e) {
+                e.printStackTrace();
             }
             return values;
         });
@@ -250,22 +271,6 @@ public abstract class MariaDBFStorage<K, V> implements ConstructableValue<K, V>,
     @Override
     public CompletableFuture<V> getFirst(String field, Object value, FilterType filterType) {
         return CompletableFuture.supplyAsync(() -> {
-//            try (final PreparedStatement statement = this.ds.getConnection().prepareStatement("SELECT * FROM " + this.table + " WHERE " + field + " = ?")) {
-//
-//                if (value instanceof UUID) {
-//                    statement.setString(1, value.toString());
-//                } else {
-//                    statement.setObject(1, value);
-//                }
-//
-//                final ResultSet resultSet = statement.executeQuery();
-//                if (resultSet.next()) {
-//                    return this.construct(resultSet);
-//                }
-//            } catch (final SQLException e) {
-//                e.printStackTrace();
-//            }
-//            return null;
             return this.get(field, value, filterType, SortingType.NONE).join().stream().findFirst().orElse(null);
         });
     }
@@ -281,7 +286,7 @@ public abstract class MariaDBFStorage<K, V> implements ConstructableValue<K, V>,
             }
 
             String values = this.getValues(value);
-            this.execute("INSERT INTO " + this.table + " (" + this.getColumns() + ") VALUES (" + values + ") ON DUPLICATE KEY UPDATE " + values);
+            this.execute("INSERT INTO " + this.table + " (" + this.getColumns() + ") VALUES (" + values + ") ON DUPLICATE KEY UPDATE " + getUpdateValues(value));
         });
     }
 
@@ -294,7 +299,7 @@ public abstract class MariaDBFStorage<K, V> implements ConstructableValue<K, V>,
                 return;
             }
             String field = idField.getName();
-            this.execute("DELETE FROM " + this.table + " WHERE " + field + " = ?;", statement -> {
+            this.execute("DELETE FROM " + this.table + " WHERE `" + field + "` = ?;", statement -> {
                 statement.setString(1, IdUtils.getId(this.valueClass, value).toString());
             });
         });
@@ -323,44 +328,38 @@ public abstract class MariaDBFStorage<K, V> implements ConstructableValue<K, V>,
     public CompletableFuture<Collection<V>> allValues() {
         return CompletableFuture.supplyAsync(() -> {
             final List<V> values = new ArrayList<>();
-            try (final PreparedStatement statement = this.ds.getConnection().prepareStatement("SELECT * FROM " + this.table)) {
-                final ResultSet resultSet = statement.executeQuery();
-                while (resultSet.next()) {
-                    values.add(this.construct(resultSet));
+            try (final Connection connection = this.ds.getConnection()) {
+                try (final PreparedStatement statement = connection.prepareStatement("SELECT * FROM " + this.table)) {
+                    final ResultSet resultSet = statement.executeQuery();
+                    while (resultSet.next()) {
+                        values.add(this.construct(resultSet));
+                    }
+                } catch (final SQLException e) {
+                    e.printStackTrace();
                 }
-            } catch (final SQLException e) {
-                e.printStackTrace();
+                return values;
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
             }
-            return values;
         });
     }
 
     private CompletableFuture<ResultSet> query(final String query, final UnsafeConsumer<PreparedStatement> statement, final UnsafeConsumer<ResultSet> result) {
         return CompletableFuture.supplyAsync(() -> {
-            try {
-                return this.ds.getConnection().prepareStatement(query);
-            } catch (SQLException e) {
-                throw new RuntimeException(e);
+            try (final Connection connection = this.ds.getConnection()) {
+                try (final PreparedStatement prepared = connection.prepareStatement(query)) {
+                    statement.accept(prepared);
+                    final ResultSet resultSet = prepared.executeQuery();
+                    result.accept(resultSet);
+                    return resultSet;
+                } catch (final SQLException e) {
+                    e.printStackTrace();
+                }
+            } catch (final SQLException e) {
+                e.printStackTrace();
             }
-        }).whenCompleteAsync((prepared, exception) -> {
-            if (exception != null) {
-                exception.printStackTrace();
-                return;
-            }
-            statement.accept(prepared);
-        }).thenApply(prepared -> {
-            try {
-                return prepared.executeQuery();
-            } catch (SQLException e) {
-                throw new RuntimeException(e);
-            }
-        }).whenCompleteAsync((set, exception) -> {
-            if (exception != null) {
-                exception.printStackTrace();
-                return;
-            }
-            result.accept(set);
-        }).toCompletableFuture();
+            return null;
+        });
     }
 
     private CompletableFuture<ResultSet> query(final String query, final UnsafeConsumer<ResultSet> result) {
@@ -374,9 +373,13 @@ public abstract class MariaDBFStorage<K, V> implements ConstructableValue<K, V>,
     }
 
     private void execute(final String statement, final UnsafeConsumer<PreparedStatement> consumer) {
-        try (final PreparedStatement prepared = this.ds.getConnection().prepareStatement(statement)) {
-            consumer.accept(prepared);
-            prepared.execute();
+        try (final Connection connection = this.ds.getConnection()) {
+            try (final PreparedStatement prepared = connection.prepareStatement(statement)) {
+                consumer.accept(prepared);
+                prepared.execute();
+            } catch (final SQLException e) {
+                e.printStackTrace();
+            }
         } catch (final SQLException e) {
             e.printStackTrace();
         }
@@ -387,14 +390,16 @@ public abstract class MariaDBFStorage<K, V> implements ConstructableValue<K, V>,
         this.execute("ALTER TABLE " + this.table + " ADD " + column + " " + type + ";");
     }
 
-    /*
+    /**
      * Will scan the class for fields and add them to the database if they don't exist
      * */
     private void scanForMissingColumns() {
-        final Field[] declaredFields = this.valueClass.getDeclaredFields();
+        List<Field> fields = Arrays.stream(this.valueClass.getDeclaredFields())
+                .filter(field -> !field.isAnnotationPresent(Transient.class))
+                .filter(field -> !Modifier.isTransient(field.getModifiers()))
+                .toList();
 
-        for (Field declaredField : declaredFields) {
-
+        for (Field declaredField : fields) {
             final String name = declaredField.getName();
             final String type = this.getType(declaredField.getType());
 
@@ -406,6 +411,8 @@ public abstract class MariaDBFStorage<K, V> implements ConstructableValue<K, V>,
                 } catch (SQLException e) {
                     this.addColumn(name, type);
                 }
+
+                resultSet.close();
             });
         }
     }
@@ -444,10 +451,11 @@ public abstract class MariaDBFStorage<K, V> implements ConstructableValue<K, V>,
                 builder.append(" PRIMARY KEY");
             }
 
+            index++;
+
             if (index != fields.size()) {
                 builder.append(", ");
             }
-            index++;
         }
         builder.append(") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
 
@@ -455,13 +463,16 @@ public abstract class MariaDBFStorage<K, V> implements ConstructableValue<K, V>,
         return builder.toString();
     }
 
-    /*
+    /**
      * This takes an SQL Result Set and parses it into an object
      * */
     @SneakyThrows
     private V construct(final ResultSet resultSet) {
         final V value = constructValue();
-        final Field[] declaredFields = this.valueClass.getDeclaredFields();
+        List<Field> declaredFields = Arrays.stream(this.valueClass.getDeclaredFields())
+                .filter(field -> !field.isAnnotationPresent(Transient.class))
+                .filter(field -> !Modifier.isTransient(field.getModifiers()))
+                .toList();
 
         for (Field declaredField : declaredFields) {
             if (declaredField.isAnnotationPresent(StorageSerialized.class)) {
@@ -481,59 +492,88 @@ public abstract class MariaDBFStorage<K, V> implements ConstructableValue<K, V>,
         return value;
     }
 
-    /*
+    /**
      * Generates an SQL String for inserting a value into the database.
      * */
     private String getValues(V value) {
         final StringBuilder builder = new StringBuilder();
         int i = 0;
-        Field[] fields = ReflectionUtil.getAllFields(valueClass);
+
+        List<Field> fields = Arrays.stream(this.valueClass.getDeclaredFields())
+                .filter(field -> !field.isAnnotationPresent(Transient.class))
+                .filter(field -> !Modifier.isTransient(field.getModifiers()))
+                .toList();
+
         for (final Field field : fields) {
-            if (field.isAnnotationPresent(Transient.class)) {
-                continue;
-            }
             if (field.isAnnotationPresent(StorageSerialized.class)) {
                 builder.append("'").append(AmethystCore.getGson().toJson(ReflectionUtil.getPrivateField(value, field.getName()))).append("'");
             } else {
                 builder.append("'").append(ReflectionUtil.getPrivateField(value, field.getName())).append("'");
             }
-            if (i != fields.length - 1) {
+            if (i != fields.size() - 1) {
                 builder.append(", ");
             }
             i++;
         }
-        return builder.substring(0, builder.length() - 1);
+
+        return builder.toString();
     }
 
-    /*
+    private String getUpdateValues(V value) {
+        final StringBuilder builder = new StringBuilder();
+        int i = 0;
+
+        List<Field> fields = Arrays.stream(this.valueClass.getDeclaredFields())
+                .filter(field -> !field.isAnnotationPresent(Transient.class))
+                .filter(field -> !Modifier.isTransient(field.getModifiers()))
+                .toList();
+
+        for (final Field field : fields) {
+            builder.append("`").append(field.getName()).append("` = VALUES(`").append(field.getName()).append("`)");
+
+            if (i != fields.size() - 1) {
+                builder.append(", ");
+            }
+
+            i++;
+        }
+
+        return builder.toString();
+    }
+
+    /**
      * Generates an SQL String for the columns associated with a value class.
      * */
     private String getColumns() {
         final StringBuilder builder = new StringBuilder();
-        for (final Field field : this.valueClass.getDeclaredFields()) {
-            if (field.isAnnotationPresent(Transient.class)) {
-                continue;
-            }
-            builder.append(field.getName()).append(",");
+
+        List<Field> fields = Arrays.stream(this.valueClass.getDeclaredFields())
+                .filter(field -> !field.isAnnotationPresent(Transient.class))
+                .filter(field -> !Modifier.isTransient(field.getModifiers()))
+                .toList();
+
+        for (final Field field : fields) {
+            builder.append("`" + field.getName() + "`").append(",");
         }
+
         return builder.substring(0, builder.length() - 1);
     }
 
 
-    /*
+    /**
      * Converts a Java class to an SQL type.
      * */
     private String getType(Class<?> type) {
         return switch (type.getName()) {
             case "java.lang.String" -> "VARCHAR(255)";
-            case "java.lang.Integer" -> "INT";
-            case "java.lang.Long" -> "BIGINT";
-            case "java.lang.Boolean" -> "BOOLEAN";
-            case "java.lang.Double" -> "DOUBLE";
-            case "java.lang.Float" -> "FLOAT";
-            case "java.lang.Short" -> "SMALLINT";
-            case "java.lang.Byte" -> "TINYINT";
-            case "java.lang.Character" -> "CHAR";
+            case "java.lang.Integer", "int" -> "INT";
+            case "java.lang.Long", "long" -> "BIGINT";
+            case "java.lang.Boolean", "boolean" -> "BOOLEAN";
+            case "java.lang.Double", "double" -> "DOUBLE";
+            case "java.lang.Float", "float" -> "FLOAT";
+            case "java.lang.Short", "short" -> "SMALLINT";
+            case "java.lang.Byte", "byte" -> "TINYINT";
+            case "java.lang.Character", "char" -> "CHAR";
             case "java.lang.Object" -> "VARCHAR(255)";
             case "java.util.UUID" -> "VARCHAR(36)";
             default -> "VARCHAR(255)";

--- a/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/fstorage/SQLFStorage.java
+++ b/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/fstorage/SQLFStorage.java
@@ -293,7 +293,7 @@ public abstract class SQLFStorage<K, V> implements ConstructableValue<K, V>, Fie
                 return;
             }
             String field = idField.getName();
-            this.execute("DELETE FROM " + this.table + " WHERE " + field + " = ?;", statement -> {
+            this.execute("DELETE FROM " + this.table + " WHERE `" + field + "` = ?;", statement -> {
                 statement.setString(1, IdUtils.getId(this.valueClass, value).toString());
             });
         });
@@ -462,7 +462,10 @@ public abstract class SQLFStorage<K, V> implements ConstructableValue<K, V>, Fie
     @SneakyThrows
     private V construct(final ResultSet resultSet) {
         final V value = constructValue();
-        final Field[] declaredFields = this.valueClass.getDeclaredFields();
+        List<Field> declaredFields = Arrays.stream(this.valueClass.getDeclaredFields())
+                .filter(field -> !field.isAnnotationPresent(Transient.class))
+                .filter(field -> !Modifier.isTransient(field.getModifiers()))
+                .toList();
 
         for (Field declaredField : declaredFields) {
             if (declaredField.isAnnotationPresent(StorageSerialized.class)) {

--- a/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/fstorage/SQLFStorage.java
+++ b/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/fstorage/SQLFStorage.java
@@ -44,7 +44,7 @@ public abstract class SQLFStorage<K, V> implements ConstructableValue<K, V>, Fie
         this.valueClass = valueClass;
         this.table = table;
         this.ds = new HikariDataSource();
-        this.ds.setMaximumPoolSize(10);
+        this.ds.setMaximumPoolSize(20);
         this.ds.setDriverClassName("com.mysql.cj.jdbc.Driver");
         this.ds.setJdbcUrl("jdbc:mysql://" + host + ":" + port + "/" + database + "?allowPublicKeyRetrieval=true&autoReconnect=true&useSSL=false");
         this.ds.addDataSourceProperty("user", username);

--- a/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/fstorage/SQLFStorage.java
+++ b/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/fstorage/SQLFStorage.java
@@ -556,17 +556,18 @@ public abstract class SQLFStorage<K, V> implements ConstructableValue<K, V>, Fie
     private String getType(Class<?> type) {
         return switch (type.getName()) {
             case "java.lang.String" -> "VARCHAR(255)";
-            case "java.lang.Integer" -> "INT";
-            case "java.lang.Long" -> "BIGINT";
-            case "java.lang.Boolean" -> "BOOLEAN";
-            case "java.lang.Double" -> "DOUBLE";
-            case "java.lang.Float" -> "FLOAT";
-            case "java.lang.Short" -> "SMALLINT";
-            case "java.lang.Byte" -> "TINYINT";
-            case "java.lang.Character" -> "CHAR";
+            case "java.lang.Integer", "int" -> "INT";
+            case "java.lang.Long", "long" -> "BIGINT";
+            case "java.lang.Boolean", "boolean" -> "BOOLEAN";
+            case "java.lang.Double", "double" -> "DOUBLE";
+            case "java.lang.Float", "float" -> "FLOAT";
+            case "java.lang.Short", "short" -> "SMALLINT";
+            case "java.lang.Byte", "byte" -> "TINYINT";
+            case "java.lang.Character", "char" -> "CHAR";
             case "java.lang.Object" -> "VARCHAR(255)";
             case "java.util.UUID" -> "VARCHAR(36)";
             default -> "VARCHAR(255)";
         };
     }
+
 }

--- a/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/fstorage/SQLFStorage.java
+++ b/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/fstorage/SQLFStorage.java
@@ -49,7 +49,6 @@ public abstract class SQLFStorage<K, V> implements ConstructableValue<K, V>, Fie
         this.ds.setJdbcUrl("jdbc:mysql://" + host + ":" + port + "/" + database + "?allowPublicKeyRetrieval=true&autoReconnect=true&useSSL=false");
         this.ds.addDataSourceProperty("user", username);
         this.ds.addDataSourceProperty("password", password);
-        this.ds.setAutoCommit(false);
         this.execute(createTableFromObject());
         this.scanForMissingColumns();
     }

--- a/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/fstorage/SQLFStorage.java
+++ b/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/fstorage/SQLFStorage.java
@@ -44,7 +44,7 @@ public abstract class SQLFStorage<K, V> implements ConstructableValue<K, V>, Fie
         this.valueClass = valueClass;
         this.table = table;
         this.ds = new HikariDataSource();
-        this.ds.setMaximumPoolSize(20);
+        this.ds.setMaximumPoolSize(10);
         this.ds.setDriverClassName("com.mysql.cj.jdbc.Driver");
         this.ds.setJdbcUrl("jdbc:mysql://" + host + ":" + port + "/" + database + "?allowPublicKeyRetrieval=true&autoReconnect=true&useSSL=false");
         this.ds.addDataSourceProperty("user", username);
@@ -439,12 +439,12 @@ public abstract class SQLFStorage<K, V> implements ConstructableValue<K, V>, Fie
                 type = "VARCHAR(255)";
             }
 
-            builder.append(name).append(" ").append(type);
+            builder.append("`" + name + "`").append(" ").append(type);
             if (name.equals(idName)) {
                 builder.append(" PRIMARY KEY");
             }
 
-            if (index != fields.size()) {
+            if (index+1 != fields.size()) {
                 builder.append(", ");
             }
             index++;

--- a/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/fstorage/SQLFStorage.java
+++ b/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/fstorage/SQLFStorage.java
@@ -392,7 +392,7 @@ public abstract class SQLFStorage<K, V> implements ConstructableValue<K, V>, Fie
         this.execute("ALTER TABLE " + this.table + " ADD " + column + " " + type + ";");
     }
 
-    /*
+    /**
      * Will scan the class for fields and add them to the database if they don't exist
      * */
     private void scanForMissingColumns() {
@@ -465,7 +465,7 @@ public abstract class SQLFStorage<K, V> implements ConstructableValue<K, V>, Fie
         return builder.toString();
     }
 
-    /*
+    /**
      * This takes an SQL Result Set and parses it into an object
      * */
     @SneakyThrows
@@ -494,7 +494,7 @@ public abstract class SQLFStorage<K, V> implements ConstructableValue<K, V>, Fie
         return value;
     }
 
-    /*
+    /**
      * Generates an SQL String for inserting a value into the database.
      * */
     private String getValues(V value) {
@@ -543,7 +543,7 @@ public abstract class SQLFStorage<K, V> implements ConstructableValue<K, V>, Fie
         return builder.toString();
     }
 
-    /*
+    /**
      * Generates an SQL String for the columns associated with a value class.
      * */
     private String getColumns() {
@@ -562,7 +562,7 @@ public abstract class SQLFStorage<K, V> implements ConstructableValue<K, V>, Fie
     }
 
 
-    /*
+    /**
      * Converts a Java class to an SQL type.
      * */
     private String getType(Class<?> type) {

--- a/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/fstorage/SQLiteFStorage.java
+++ b/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/fstorage/SQLiteFStorage.java
@@ -437,7 +437,7 @@ public abstract class SQLiteFStorage<K, V> implements ConstructableValue<K, V>, 
                 type = "VARCHAR(255)";
             }
 
-            builder.append(name).append(" ").append(type);
+            builder.append("`" + name + "`").append(" ").append(type);
             if (name.equals(idName)) {
                 builder.append(" PRIMARY KEY");
             }

--- a/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/statelessfstorage/StatelessMariaDBStorage.java
+++ b/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/statelessfstorage/StatelessMariaDBStorage.java
@@ -15,13 +15,11 @@ import wtf.casper.amethyst.core.utils.AmethystLogger;
 import wtf.casper.amethyst.core.utils.ReflectionUtil;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 public abstract class StatelessMariaDBStorage<K, V> implements ConstructableValue<K, V>, StatelessFieldStorage<K, V> {
@@ -232,9 +230,6 @@ public abstract class StatelessMariaDBStorage<K, V> implements ConstructableValu
         final Field[] declaredFields = this.valueClass.getDeclaredFields();
 
         for (Field declaredField : declaredFields) {
-            if (declaredField.isAnnotationPresent(Transient.class)) {
-                continue;
-            }
 
             final String name = declaredField.getName();
             final String type = this.getType(declaredField.getType());
@@ -251,14 +246,18 @@ public abstract class StatelessMariaDBStorage<K, V> implements ConstructableValu
         }
     }
 
-    /*
+    /**
      * Generate an SQL Script to create the table based on the class
      * */
     private String createTableFromObject() {
         final StringBuilder builder = new StringBuilder();
-        final Field[] declaredFields = this.valueClass.getDeclaredFields();
 
-        if (declaredFields.length == 0) {
+        List<Field> fields = Arrays.stream(this.valueClass.getDeclaredFields())
+                .filter(field -> !field.isAnnotationPresent(Transient.class))
+                .filter(field -> !Modifier.isTransient(field.getModifiers()))
+                .toList();
+
+        if (fields.size() == 0) {
             return "";
         }
 
@@ -267,11 +266,7 @@ public abstract class StatelessMariaDBStorage<K, V> implements ConstructableValu
         String idName = IdUtils.getIdName(valueClass);
 
         int index = 0;
-        for (Field declaredField : declaredFields) {
-            index++;
-            if (declaredField.isAnnotationPresent(Transient.class)) {
-                continue;
-            }
+        for (Field declaredField : fields) {
 
             final String name = declaredField.getName();
             String type = this.getType(declaredField.getType());
@@ -285,11 +280,14 @@ public abstract class StatelessMariaDBStorage<K, V> implements ConstructableValu
                 builder.append(" PRIMARY KEY");
             }
 
-            if (index != declaredFields.length) {
+            if (index != fields.size()) {
                 builder.append(", ");
             }
+            index++;
         }
-        builder.append(") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;");
+        builder.append(") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;");
+
+        AmethystLogger.debug("Generated SQL: " + builder);
         return builder.toString();
     }
 
@@ -302,9 +300,6 @@ public abstract class StatelessMariaDBStorage<K, V> implements ConstructableValu
         final Field[] declaredFields = this.valueClass.getDeclaredFields();
 
         for (Field declaredField : declaredFields) {
-            if (declaredField.isAnnotationPresent(Transient.class)) {
-                continue;
-            }
             if (declaredField.isAnnotationPresent(StorageSerialized.class)) {
                 final String name = declaredField.getName();
                 final String string = resultSet.getString(name);

--- a/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/statelessfstorage/StatelessMariaDBStorage.java
+++ b/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/statelessfstorage/StatelessMariaDBStorage.java
@@ -275,7 +275,7 @@ public abstract class StatelessMariaDBStorage<K, V> implements ConstructableValu
                 type = "VARCHAR(255)";
             }
 
-            builder.append(name).append(" ").append(type);
+            builder.append("`" + name + "`").append(" ").append(type);
             if (name.equals(idName)) {
                 builder.append(" PRIMARY KEY");
             }

--- a/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/statelessfstorage/StatelessSQLFStorage.java
+++ b/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/statelessfstorage/StatelessSQLFStorage.java
@@ -417,7 +417,7 @@ public abstract class StatelessSQLFStorage<K, V> implements ConstructableValue<K
                 type = "VARCHAR(255)";
             }
 
-            builder.append(name).append(" ").append(type);
+            builder.append("`" + name + "`").append(" ").append(type);
             if (name.equals(idName)) {
                 builder.append(" PRIMARY KEY");
             }

--- a/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/statelessfstorage/StatelessSQLFStorage.java
+++ b/standalone/src/main/java/wtf/casper/amethyst/core/storage/impl/statelessfstorage/StatelessSQLFStorage.java
@@ -44,7 +44,6 @@ public abstract class StatelessSQLFStorage<K, V> implements ConstructableValue<K
         this.ds.setJdbcUrl("jdbc:mysql://" + host + ":" + port + "/" + database + "?allowPublicKeyRetrieval=true&autoReconnect=true&useSSL=false");
         this.ds.addDataSourceProperty("user", username);
         this.ds.addDataSourceProperty("password", password);
-        this.ds.setAutoCommit(false);
         this.execute(createTableFromObject());
         this.scanForMissingColumns();
     }


### PR DESCRIPTION
This PR fixes an issue with tables generating invalid, such as `(COLUMN, COLUMN, )`, alongside adding backticks around column names - mainly around reserved keywords such as `key` where MySQL would error out.